### PR TITLE
ADD: Change the Types to allow a user to have multiple businesses

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,6 +102,19 @@ export type StorageObject = {
 	nodeUrl: string;
 };
 
+export type BusinessObject = {
+	businessName: string; // Business name
+	businessId: string; // Business ID
+	businessPub: string; // Business public key
+	role: Role | null; // User's role
+	macaroon: string; // User's macaroon - only available to manager & merchant roles. Cashiers will be empty string
+	nodeId: string; // Business node ID
+	nodeUrl: string; // Business node URL
+	mnemonic: string; // Mnemonic seed phrase
+	encipheredSeed: string; // Enciphered seed
+	nodePassword: string; // Node password
+};
+
 export type SettingsObject = {
 	priv: Uint8Array; // User's private key
 	pub: Uint8Array; // User's public key
@@ -111,15 +124,8 @@ export type SettingsObject = {
 	challengeExpires: number; // Challenge expiration timestamp
 	bearerToken: string; // Bearer token for API calls
 	musqetPub: string; // Musqet public key
-	business: string; // Business name
-	businessPub: string; // Business public key
-	role: Role | null; // User's role
-	macaroon: string; // User's macaroon - only available to manager & merchant roles. Cashiers will be empty string
-	nodeId: string; // Business node ID
-	nodeUrl: string; // Business node URL
-	mnemonic: string; // Mnemonic seed phrase
-	encipheredSeed: string; // Enciphered seed
-	nodePassword: string; // Node password
+	businesses: BusinessObject[]; // Array of businesses
+	currentBusiness: number; // Index of Current business
 };
 
 export type SettingsValue = string | Uint8Array | number;


### PR DESCRIPTION
# Fixes: #18 

## Description

Changed the storage object to have an array of business objects for merchants to be able to have more than one business.

## Changes

- Add `currentBusiness` property that points to the index of the business the user is interacting with
- Move all business related properties to their own object and made a property `businesses` which is an array of business objects

## PR Tasks

- [x] Open PR
- [ ] run `npm run test` --> no failing unit tests
- [x] run `npm run format`

Tests failing because of API errors